### PR TITLE
fix:fix/error-propagating

### DIFF
--- a/rust/examples/cpi/programs/russian-roulette/src/misc.rs
+++ b/rust/examples/cpi/programs/russian-roulette/src/misc.rs
@@ -9,11 +9,7 @@ pub fn get_account_data(account_info: &AccountInfo) -> Result<RandomnessAccountD
         return Err(ProgramError::UninitializedAccount);
     }
 
-    let account = RandomnessAccountData::try_deserialize(&mut &account_info.data.borrow()[..])?;
+    let account = RandomnessAccountData::try_deserialize(&mut &account_info.data.borrow()[..]).map_err(|_| ProgramError::UninitializedAccount)?;
 
-    if false {
-        Err(ProgramError::UninitializedAccount)
-    } else {
-        Ok(account)
-    }
+    Ok(account)
 }


### PR DESCRIPTION
the origin implementation 
```rust
if false {
        Err(ProgramError::UninitializedAccount)
    } else {
        Ok(account)
    }
```
the line `Err(ProgramError::UninitializedAccount)` will never be reached, as there is a hardcoded value of `false`

in fact, in 
```rust
let account = RandomnessAccountData::try_deserialize(&mut &account_info.data.borrow()[..])?;
```
when `?` is applied, in case there is any error from `try_deserialize`, the error will return from this line immediately,  the remaining logic will be skipped.

To keep the code tidy, I provided this PR. 
