### PR TITLE
fix: handle when historical prioritization fees are empty

### DIFF
--- a/callback/rust/sdk/src/sdk/priority.rs
+++ b/callback/rust/sdk/src/sdk/priority.rs
@@ -23,6 +23,10 @@ pub async fn get_recommended_micro_lamport_fee(
     }
 
     let mut fees = client.get_recent_prioritization_fees(&[]).await?;
+    
+    if fees.is_empty() {
+        return Ok(None);
+    }
 
     // Get the median fee from the most recent recent 150 slots' prioritization fee
     fees.sort_unstable_by_key(|fee| fee.prioritization_fee);


### PR DESCRIPTION
if you run the rust sdk on a newly started local env, `solana-test-validator`, it may have no finished transactions, so `get_recent_prioritization_fees` can return an empty `fees` vec. this edge case should be handled, otherwise it would panic when it goes to

```rust

let mut median_priority_fee = if fees.len() % 2 == 0 {
        (fees[median_index - 1].prioritization_fee + fees[median_index].prioritization_fee) / 2
    }
    
 ```   
 in there `fees[median_index - 1]` becomes `fees[-1]`
 
 I did some research, I saw this case already handled in the javascript implementation, using 

https://github.com/orao-network/solana-vrf/blob/25baa12a1ba77bd330928e2b3bd8f2456197525a/callback/js/src/index.ts#L1406-L1410

 so for any of the 2 reasons, please merge this PK.